### PR TITLE
Use matrix.to for room link

### DIFF
--- a/xest-site/templates/default.html
+++ b/xest-site/templates/default.html
@@ -18,7 +18,7 @@
                 <a href="/">Home</a>
                 <a href="https://github.com/jhgarner/Xest-Window-Manager">Github</a>
                 <a href="/userguide.html">User Guide</a>
-                <a href="https://app.element.io/#/room/!iaDRSCyjeRToGSBZfL:matrix.org?via=matrix.org">Chat</a>
+                <a href="https://matrix.to/#/!iaDRSCyjeRToGSBZfL:matrix.org?via=matrix.org">Chat</a>
             </nav>
         </header>
 


### PR DESCRIPTION
The current link doesn't seem to work for me.  Perhaps it's because I'm not
using the matrix.org homeserver?